### PR TITLE
Optimized runtime reducer

### DIFF
--- a/config/.credo.exs
+++ b/config/.credo.exs
@@ -8,6 +8,7 @@
       },
       checks: [
         {Credo.Check.Design.TagTODO, exit_status: 0},
+        {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 120},
       ]
     }
   ]

--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -1,1 +1,1 @@
-lib/multiverse.ex:72: Expression produces a value of type [any()], but this value is unmatched
+lib/multiverse.ex:73: Expression produces a value of type [any()], but this value is unmatched

--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -1,2 +1,1 @@
-lib/multiverse.ex:70: Expression produces a value of type [any()], but this value is unmatched
-lib/multiverse.ex:46: Invalid type specification for function 'Elixir.Multiverse':init/1. The success typing is ([{atom(),_}]) -> #{'adapter':=atom(), 'gates':=map(), 'version_header':=_}
+lib/multiverse.ex:72: Expression produces a value of type [any()], but this value is unmatched

--- a/lib/multiverse.ex
+++ b/lib/multiverse.ex
@@ -7,6 +7,7 @@ defmodule Multiverse do
   For more information see [README.md](https://github.com/Nebo15/multiverse/).
   """
   @behaviour Plug
+  alias Plug.Conn
 
   @type config :: %{
           adapter: module,
@@ -105,11 +106,11 @@ defmodule Multiverse do
     conn
     |> apply_request_changes(version_schema)
     |> apply_response_changes(version_schema)
-    |> Plug.Conn.put_private(:multiverse_version_schema, version_schema)
+    |> Conn.put_private(:multiverse_version_schema, version_schema)
   end
 
   defp fetch_consumer_api_version(adapter, conn, version_header) do
-    case Plug.Conn.get_req_header(conn, version_header) do
+    case Conn.get_req_header(conn, version_header) do
       [] -> adapter.fetch_default_version(conn)
       ["" | _] -> adapter.fetch_default_version(conn)
       [version_or_channel | _] -> adapter.resolve_version_or_channel(conn, version_or_channel)
@@ -138,7 +139,7 @@ defmodule Multiverse do
 
   defp apply_response_changes(conn, %{changes: changes}) do
     Enum.reduce(changes, conn, fn change_mod, conn ->
-      Plug.Conn.register_before_send(conn, fn conn ->
+      Conn.register_before_send(conn, fn conn ->
         change_mod.handle_response(conn)
       end)
     end)

--- a/lib/multiverse/adapter.ex
+++ b/lib/multiverse/adapter.ex
@@ -5,7 +5,8 @@ defmodule Multiverse.Adapter do
 
   @type version :: any
   @type changes :: [module]
-  @type gates :: [%{version => changes}]
+  @typedoc "Gates are stored in a reversed chronological order"
+  @type gates :: [{version, changes}]
 
   @doc """
   Initialize adapter configuration at compile time.

--- a/test/multiverse/adapters/iso_date_test.exs
+++ b/test/multiverse/adapters/iso_date_test.exs
@@ -6,7 +6,7 @@ defmodule Multiverse.Adapters.ISODateTest do
     %{conn: conn(:get, "/foo")}
   end
 
-  test "chronologically orders gates" do
+  test "orders gates in a reverse chronological order" do
     assert %{gates: gates} =
              Multiverse.init(
                gates: %{
@@ -14,66 +14,67 @@ defmodule Multiverse.Adapters.ISODateTest do
                  ~D[2001-02-01] => [],
                  ~D[2001-01-01] => [],
                  ~D[2001-02-02] => []
-               }
+               },
+               adapter: Multiverse.Adapters.ISODate
              )
 
     assert gates ==
-             %{
-               ~D[2001-01-01] => [],
-               ~D[2001-02-01] => [],
-               ~D[2001-02-02] => [],
-               ~D[2002-03-01] => []
-             }
+             [
+               {~D[2002-03-01], []},
+               {~D[2001-02-02], []},
+               {~D[2001-02-01], []},
+               {~D[2001-01-01], []}
+             ]
   end
 
   test "fetches API version from date in x-api-version header", %{conn: conn} do
-    opts = %{adapter: Multiverse.Adapters.ISODate, gates: %{}, version_header: "x-api-version"}
+    config = %{adapter: Multiverse.Adapters.ISODate, gates: [], version_header: "x-api-version"}
 
     conn = %{conn | req_headers: [{"x-api-version", "2001-01-01"}]}
-    conn = Multiverse.call(conn, opts)
+    conn = Multiverse.call(conn, config)
 
     assert conn.private.multiverse_version_schema.version == ~D[2001-01-01]
   end
 
   test "resolves latest channel to current date", %{conn: conn} do
-    opts = %{adapter: Multiverse.Adapters.ISODate, gates: %{}, version_header: "x-api-version"}
+    config = %{adapter: Multiverse.Adapters.ISODate, gates: [], version_header: "x-api-version"}
 
     conn = %{conn | req_headers: [{"x-api-version", "latest"}]}
-    conn = Multiverse.call(conn, opts)
+    conn = Multiverse.call(conn, config)
 
     assert conn.private.multiverse_version_schema.version == Date.utc_today()
   end
 
   test "resolves edge channel to latest gate", %{conn: conn} do
-    opts = %{
+    config = %{
       adapter: Multiverse.Adapters.ISODate,
-      gates: %{
-        ~D[2002-03-01] => [],
-        ~D[2001-02-01] => []
-      },
+      gates: [
+        {~D[2001-02-01], []},
+        {~D[2002-03-01], []}
+      ],
       version_header: "x-api-version"
     }
 
     conn = %{conn | req_headers: [{"x-api-version", "edge"}]}
-    conn = Multiverse.call(conn, opts)
+    conn = Multiverse.call(conn, config)
 
     assert conn.private.multiverse_version_schema.version == "edge"
   end
 
   test "resolves malformed version to current gate", %{conn: conn} do
-    opts = %{adapter: Multiverse.Adapters.ISODate, gates: %{}, version_header: "x-api-version"}
+    config = %{adapter: Multiverse.Adapters.ISODate, gates: [], version_header: "x-api-version"}
 
     conn = %{conn | req_headers: [{"x-api-version", "not-a-date"}]}
-    conn = Multiverse.call(conn, opts)
+    conn = Multiverse.call(conn, config)
 
     assert conn.private.multiverse_version_schema.version == Date.utc_today()
   end
 
   test "fetches API version from custom header", %{conn: conn} do
-    opts = %{adapter: Multiverse.Adapters.ISODate, gates: %{}, version_header: "x-my-api-version"}
+    config = %{adapter: Multiverse.Adapters.ISODate, gates: [], version_header: "x-my-api-version"}
 
     conn = %{conn | req_headers: [{"x-my-api-version", "2001-01-01"}]}
-    conn = Multiverse.call(conn, opts)
+    conn = Multiverse.call(conn, config)
 
     assert conn.private.multiverse_version_schema.version == ~D[2001-01-01]
   end


### PR DESCRIPTION
Instead of going trough all gates on each change, we can stored them in
a reverse order and stop reducer whenever we see first version that
does not need to be applied to the request.