### PR TITLE
Default version config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,9 @@ Default adapter is `Multiverse.Adapters.ISODate` which works similarly to the ol
 
 # Changelog for v1.1
 
-`Multiverse.Adapters.ISODate` now does not apply changes occurred on a date/version specified by an API consumer. Since we expect that user would sett API docs that already include latest changes on that day.
+* `Multiverse.Adapters.ISODate` now does not apply changes occurred on a date/version specified by an API consumer. Since we expect that user would sett API docs that already include latest changes on that day.
+
+# Changelog for v2.0
+
+* `Multiverse.Adapters.ISODate` now now requires a `default_version` config. By introducing it we want to make sure that developers that integrate Multiverse are fully aware of the default behaviour, which should be picked according to current API clients demands.
+* Runtime execution performance should be slightly better because we won't traverse all gates on each request.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The package (take look at [hex.pm](https://hex.pm/packages/multiverse)) can be i
 
   ```elixir
   def deps do
-    [{:multiverse, "~> 1.1.0"}]
+    [{:multiverse, "~> 2.0.0"}]
   end
   ```
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The package (take look at [hex.pm](https://hex.pm/packages/multiverse)) can be i
     plug :accepts, ["json"]
     plug :put_secure_browser_headers
 
-    plug Multiverse
+    plug Multiverse, default_version: :latest
   end
   ```
 
@@ -94,9 +94,11 @@ The package (take look at [hex.pm](https://hex.pm/packages/multiverse)) can be i
     plug :accepts, ["json"]
     plug :put_secure_browser_headers
 
-    plug Multiverse, gates: %{
-      ~D[2016-07-21] => [AccountTypeChange]
-    }
+    plug Multiverse,
+      default_version: :latest,
+      gates: %{
+        ~D[2016-07-21] => [AccountTypeChange]
+      }
   end
   ```
 
@@ -112,6 +114,7 @@ The package (take look at [hex.pm](https://hex.pm/packages/multiverse)) can be i
     plug :put_secure_browser_headers
 
     plug Multiverse,
+      default_version: :latest,
       version_header: "x-my-version-header",
       gates: %{
         ~D[2016-07-21] => [AccountTypeChange]
@@ -129,6 +132,7 @@ The package (take look at [hex.pm](https://hex.pm/packages/multiverse)) can be i
     plug :put_secure_browser_headers
 
     plug Multiverse,
+      default_version: :latest,
       adapter: MyApp.SmartMultiverseAdapter,
       gates: %{
         ~D[2016-07-21] => [AccountTypeChange]
@@ -155,6 +159,7 @@ The package (take look at [hex.pm](https://hex.pm/packages/multiverse)) can be i
   use Mix.Config
 
   config :multiverse, MyApp.Endpoint,
+    default_version: :latest,
     gates: %{
       ~D[2016-07-21] => [AccountTypeChange]
     }

--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -1,1 +1,1 @@
-lib/multiverse.ex:74: Expression produces a value of type [any()], but this value is unmatched
+Expression produces a value of type [any()], but this value is unmatched

--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -1,1 +1,2 @@
 Expression produces a value of type [any()], but this value is unmatched
+test/support/test_adapter.ex

--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -1,1 +1,1 @@
-lib/multiverse.ex:73: Expression produces a value of type [any()], but this value is unmatched
+lib/multiverse.ex:74: Expression produces a value of type [any()], but this value is unmatched

--- a/lib/multiverse/adapters/iso_date.ex
+++ b/lib/multiverse/adapters/iso_date.ex
@@ -3,49 +3,105 @@ defmodule Multiverse.Adapters.ISODate do
   Adapter that fetches ISO-8601 date from request header and `Elixir.Date`
   to resolve changes that must be applied to the connection.
 
-  Current date is used as fallback when:
-    * version header is not present in request;
-    * value of a version header is malformed (and warning is logged);
-    * `latest` channel is used instead of date.
+  This adapter requires you to configure which version is used by default,
+  when value in a header was malformed or not set. It's configured via `:default_version`,
+  supported values:
 
-  When `edge` channel is used instead of date, no changes are applied to the connection.
+    * `:first` - apply all gates by default. This option is useful when you integrate Multiverse in existing project \
+    and API consumers are not ready to accept latest changes by default;
+    * `:latest` - user current date as default version. This option is useful when there are
+    no legacy clients or there was no breaking changes before those clients started to send API version.
+
+  ## Version Channels
+
+  Consumers can use two channels instead of date in version header:
+
+   * `latest` - apply only changes scheduled for future (with a date later than date when request arrived);
+   * `edge` - do not apply any changes.
   """
   require Logger
-
   @behaviour Multiverse.Adapter
+
+  @default_version_values [:latest, :oldest]
 
   @typep version :: Date.t()
 
-  def init(_adapter, opts), do: {:ok, opts}
+  @doc """
+  Initializes adapter configuration at compile time.
 
-  @spec version_comparator(v1 :: version, v2 :: version) :: boolean
+  Raises when `:default_version` option is not set.
+  """
+  def init(_adapter, opts) do
+    default_version = Keyword.get(opts, :default_version)
+
+    unless default_version do
+      raise ArgumentError, "Multiverse.Adapters.ISODate :default_version config is not set"
+    end
+
+    unless default_version in @default_version_values do
+      default_version_values_strings = Enum.map(@default_version_values, &inspect/1)
+
+      raise ArgumentError,
+            "invalid Multiverse.Adapters.ISODate :default_version config value, " <>
+              "possible values: #{Enum.join(default_version_values_strings, ", ")}, " <>
+              "got: #{inspect(default_version)}"
+    end
+
+    {:ok, opts}
+  end
+
+  @spec version_comparator(v1 :: version(), v2 :: version()) :: boolean
   def version_comparator("edge", _v2), do: false
   def version_comparator(v1, v2), do: Date.compare(v1, v2) == :lt
 
-  @spec fetch_default_version(conn :: Plug.Conn.t()) :: {:ok, version, Plug.Conn.t()}
-  def fetch_default_version(conn), do: {:ok, Date.utc_today(), conn}
-
-  @spec resolve_version_or_channel(conn :: Plug.Conn.t(), channel_or_version :: String.t()) :: {
-          :ok,
-          version,
-          Plug.Conn.t()
-        }
-  def resolve_version_or_channel(conn, "latest") do
-    fetch_default_version(conn)
+  @spec fetch_default_version(conn :: Plug.Conn.t(), adapter_config :: Multiverse.Adapter.config()) ::
+          {:ok, version, Plug.Conn.t()}
+  def fetch_default_version(conn, adapter_config) do
+    case Keyword.get(adapter_config, :default_version) do
+      :latest -> {:ok, Date.utc_today(), conn}
+      :oldest -> {:ok, fetch_oldest_version(adapter_config), conn}
+    end
   end
 
-  def resolve_version_or_channel(conn, "edge") do
+  defp fetch_oldest_version(adapter_config) do
+    with gates when length(gates) > 0 <- Keyword.fetch!(adapter_config, :gates) do
+      gates |> List.last() |> elem(0) |> Date.add(-1)
+    else
+      [] ->
+        :ok =
+          Logger.warn(fn ->
+            "[Multiverse] You specified default_version: :oldest but there are no gates, failing back to the current date"
+          end)
+
+        Date.utc_today()
+    end
+  end
+
+  @spec resolve_version_or_channel(
+          conn :: Plug.Conn.t(),
+          channel_or_version :: String.t(),
+          adapter_config :: Multiverse.Adapter.config()
+        ) :: {:ok, version, Plug.Conn.t()}
+  def resolve_version_or_channel(conn, "latest", _adapter_config) do
+    {:ok, Date.utc_today(), conn}
+  end
+
+  def resolve_version_or_channel(conn, "edge", _adapter_config) do
     {:ok, "edge", conn}
   end
 
-  def resolve_version_or_channel(conn, version) do
+  def resolve_version_or_channel(conn, version, adapter_config) do
     case Date.from_iso8601(version) do
       {:ok, date} ->
         {:ok, date, conn}
 
       {:error, reason} ->
-        :ok = Logger.warn("Malformed version header: `#{inspect(reason)}`, failing back to the default version")
-        fetch_default_version(conn)
+        :ok =
+          Logger.warn(fn ->
+            "[Multiverse] Malformed version header: #{inspect(reason)}, failing back to the default version"
+          end)
+
+        fetch_default_version(conn, adapter_config)
     end
   end
 end

--- a/lib/multiverse/adapters/iso_date.ex
+++ b/lib/multiverse/adapters/iso_date.ex
@@ -70,7 +70,8 @@ defmodule Multiverse.Adapters.ISODate do
       [] ->
         :ok =
           Logger.warn(fn ->
-            "[Multiverse] You specified default_version: :oldest but there are no gates, failing back to the current date"
+            "[Multiverse] You specified default_version: :oldest but there are no gates, " <>
+              "failing back to the current date"
           end)
 
         Date.utc_today()

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Multiverse.Mixfile do
   use Mix.Project
 
-  @version "1.1.0"
+  @version "2.0.0"
 
   def project do
     [

--- a/test/multiverse/adapters/iso_date_test.exs
+++ b/test/multiverse/adapters/iso_date_test.exs
@@ -2,21 +2,49 @@ defmodule Multiverse.Adapters.ISODateTest do
   use ExUnit.Case, async: true
   use Plug.Test
 
+  defmodule ChangeOne do
+    use Multiverse.ChangeFactory
+  end
+
+  defmodule ChangeTwo do
+    use Multiverse.ChangeFactory
+  end
+
+  defmodule ChangeThree do
+    use Multiverse.ChangeFactory
+  end
+
   setup do
     %{conn: conn(:get, "/foo")}
   end
 
+  test "raises when default_version is not set" do
+    assert_raise ArgumentError, "Multiverse.Adapters.ISODate :default_version config is not set", fn ->
+      Multiverse.init([])
+    end
+  end
+
+  test "raises on invalid default_version value" do
+    message =
+      "invalid Multiverse.Adapters.ISODate :default_version config value, " <>
+        "possible values: :latest, :oldest, got: :invalid"
+
+    assert_raise ArgumentError, message, fn ->
+      Multiverse.init(default_version: :invalid)
+    end
+  end
+
   test "orders gates in a reverse chronological order" do
-    assert %{gates: gates} =
-             Multiverse.init(
-               gates: %{
-                 ~D[2002-03-01] => [],
-                 ~D[2001-02-01] => [],
-                 ~D[2001-01-01] => [],
-                 ~D[2001-02-02] => []
-               },
-               adapter: Multiverse.Adapters.ISODate
-             )
+    %{gates: gates} =
+      Multiverse.init(
+        gates: %{
+          ~D[2002-03-01] => [],
+          ~D[2001-02-01] => [],
+          ~D[2001-01-01] => [],
+          ~D[2001-02-02] => []
+        },
+        default_version: :latest
+      )
 
     assert gates ==
              [
@@ -27,55 +55,84 @@ defmodule Multiverse.Adapters.ISODateTest do
              ]
   end
 
-  test "fetches API version from date in x-api-version header", %{conn: conn} do
-    config = %{adapter: Multiverse.Adapters.ISODate, gates: [], version_header: "x-api-version"}
+  test "resolves empty version to current date on default_version: :latest", %{conn: conn} do
+    config = Multiverse.init(default_version: :latest)
+    conn = %{conn | req_headers: [{"x-api-version", ""}]}
+    conn = Multiverse.call(conn, config)
+    assert conn.private.multiverse_version_schema.version == Date.utc_today()
+  end
 
+  test "resolves empty version to one day before first gate on default_version: :oldest", %{conn: conn} do
+    today = Date.utc_today()
+    tomorrow = Date.add(today, 1)
+
+    config =
+      Multiverse.init(
+        default_version: :oldest,
+        gates: [
+          {tomorrow, [ChangeThree]},
+          {today, [ChangeTwo]},
+          {~D[2001-02-01], [ChangeOne]}
+        ]
+      )
+
+    conn = %{conn | req_headers: [{"x-api-version", ""}]}
+    conn = Multiverse.call(conn, config)
+    assert conn.private.multiverse_version_schema.version == ~D[2001-01-31]
+  end
+
+  test "resolves empty version to current date on default_version: :oldest and no empty gates", %{conn: conn} do
+    config = Multiverse.init(default_version: :oldest)
+    conn = %{conn | req_headers: [{"x-api-version", ""}]}
+    conn = Multiverse.call(conn, config)
+    assert conn.private.multiverse_version_schema.version == Date.utc_today()
+  end
+
+  test "resolves malformed version to default", %{conn: conn} do
+    config = Multiverse.init(default_version: :latest)
+    conn = %{conn | req_headers: [{"x-api-version", "not-a-date"}]}
+    conn = Multiverse.call(conn, config)
+    assert conn.private.multiverse_version_schema.version == Date.utc_today()
+  end
+
+  test "fetches API version from date in x-api-version header", %{conn: conn} do
+    config = Multiverse.init(default_version: :latest)
     conn = %{conn | req_headers: [{"x-api-version", "2001-01-01"}]}
     conn = Multiverse.call(conn, config)
-
     assert conn.private.multiverse_version_schema.version == ~D[2001-01-01]
   end
 
   test "resolves latest channel to current date", %{conn: conn} do
-    config = %{adapter: Multiverse.Adapters.ISODate, gates: [], version_header: "x-api-version"}
-
+    config = Multiverse.init(default_version: :oldest)
     conn = %{conn | req_headers: [{"x-api-version", "latest"}]}
     conn = Multiverse.call(conn, config)
-
     assert conn.private.multiverse_version_schema.version == Date.utc_today()
   end
 
-  test "resolves edge channel to latest gate", %{conn: conn} do
-    config = %{
-      adapter: Multiverse.Adapters.ISODate,
-      gates: [
-        {~D[2001-02-01], []},
-        {~D[2002-03-01], []}
-      ],
-      version_header: "x-api-version"
-    }
+  test "does not apply any changes on edge version", %{conn: conn} do
+    today = Date.utc_today()
+    tomorrow = Date.add(today, 1)
+
+    config =
+      Multiverse.init(
+        default_version: :latest,
+        gates: [
+          {tomorrow, [ChangeThree]},
+          {today, [ChangeTwo]},
+          {~D[2001-02-01], [ChangeOne]}
+        ]
+      )
 
     conn = %{conn | req_headers: [{"x-api-version", "edge"}]}
-    conn = Multiverse.call(conn, config)
+
+    conn =
+      conn
+      |> Multiverse.call(config)
+      |> send_resp(204, "")
 
     assert conn.private.multiverse_version_schema.version == "edge"
-  end
-
-  test "resolves malformed version to current gate", %{conn: conn} do
-    config = %{adapter: Multiverse.Adapters.ISODate, gates: [], version_header: "x-api-version"}
-
-    conn = %{conn | req_headers: [{"x-api-version", "not-a-date"}]}
-    conn = Multiverse.call(conn, config)
-
-    assert conn.private.multiverse_version_schema.version == Date.utc_today()
-  end
-
-  test "fetches API version from custom header", %{conn: conn} do
-    config = %{adapter: Multiverse.Adapters.ISODate, gates: [], version_header: "x-my-api-version"}
-
-    conn = %{conn | req_headers: [{"x-my-api-version", "2001-01-01"}]}
-    conn = Multiverse.call(conn, config)
-
-    assert conn.private.multiverse_version_schema.version == ~D[2001-01-01]
+    assert conn.private.multiverse_version_schema.changes == []
+    refute Map.get(conn.assigns, :applied_changes)
+    assert conn.before_send == []
   end
 end

--- a/test/support/test_adapter.ex
+++ b/test/support/test_adapter.ex
@@ -6,7 +6,7 @@ defmodule Multiverse.TestAdapter do
 
   def version_comparator(_v1, _v2), do: raise("not implemented")
 
-  def fetch_default_version(_conn), do: raise("not implemented")
+  def fetch_default_version(_conn, _adapter_config), do: raise("not implemented")
 
-  def resolve_version_or_channel(_conn, _version), do: raise("not implemented")
+  def resolve_version_or_channel(_conn, _version, _adapter_config), do: raise("not implemented")
 end


### PR DESCRIPTION
This PR would force users to decide which version should be used by default. This is done to make sure that it’s behaviours is clear to developers that integrate Multiverse in existing projects.

It should be merged after #9 